### PR TITLE
RMB-739: connectionReleaseDelay PoolOption

### DIFF
--- a/vertx-sql-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-sql-client/src/main/asciidoc/dataobjects.adoc
@@ -12,6 +12,10 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[connectionReleaseDelay]]`@connectionReleaseDelay`|`Number (int)`|+++
+Set the idle time in milliseconds before closing an connection waiting in the pool.
+ If 0 the connection will never be closed.
++++
 |[[maxSize]]`@maxSize`|`Number (int)`|+++
 Set the maximum pool size
 +++

--- a/vertx-sql-client/src/main/generated/io/vertx/sqlclient/PoolOptionsConverter.java
+++ b/vertx-sql-client/src/main/generated/io/vertx/sqlclient/PoolOptionsConverter.java
@@ -15,6 +15,11 @@ public class PoolOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PoolOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "connectionReleaseDelay":
+          if (member.getValue() instanceof Number) {
+            obj.setConnectionReleaseDelay(((Number)member.getValue()).intValue());
+          }
+          break;
         case "maxSize":
           if (member.getValue() instanceof Number) {
             obj.setMaxSize(((Number)member.getValue()).intValue());
@@ -34,6 +39,7 @@ public class PoolOptionsConverter {
   }
 
   public static void toJson(PoolOptions obj, java.util.Map<String, Object> json) {
+    json.put("connectionReleaseDelay", obj.getConnectionReleaseDelay());
     json.put("maxSize", obj.getMaxSize());
     json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
@@ -19,6 +19,7 @@ package io.vertx.sqlclient;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import java.util.Objects;
 
 /**
  * The options for configuring a connection pool.
@@ -38,8 +39,14 @@ public class PoolOptions {
    */
   public static final int DEFAULT_MAX_WAIT_QUEUE_SIZE = -1;
 
+  /**
+   * Default time before closing an idle connection that waits in the pool = 0 (never close).
+   */
+  public static final int DEFAULT_CONNECTION_RELEASE_DELAY = 0;
+
   private int maxSize = DEFAULT_MAX_SIZE;
   private int maxWaitQueueSize = DEFAULT_MAX_WAIT_QUEUE_SIZE;
+  private int connectionReleaseDelay = DEFAULT_CONNECTION_RELEASE_DELAY;
 
   public PoolOptions() {
   }
@@ -51,6 +58,7 @@ public class PoolOptions {
   public PoolOptions(PoolOptions other) {
     maxSize = other.maxSize;
     maxWaitQueueSize = other.maxWaitQueueSize;
+    connectionReleaseDelay = other.connectionReleaseDelay;
   }
 
   /**
@@ -93,6 +101,26 @@ public class PoolOptions {
     return this;
   }
 
+  /**
+   * @return time in milliseconds before closing an idle connection that waits in the pool.
+   *            If 0 the connection will never be closed.
+   */
+  public int getConnectionReleaseDelay() {
+    return connectionReleaseDelay;
+  }
+
+  /**
+   * Set the idle time in milliseconds before closing a connection waiting in the pool.
+   * If 0 the connection will never be closed.
+   *
+   * @param connectionReleaseDelay  idle time in milliseconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setConnectionReleaseDelay(int connectionReleaseDelay) {
+    this.connectionReleaseDelay = connectionReleaseDelay;
+    return this;
+  }
+
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     PoolOptionsConverter.toJson(this, json);
@@ -101,21 +129,20 @@ public class PoolOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof PoolOptions)) return false;
-    if (!super.equals(o)) return false;
-
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PoolOptions)) {
+      return false;
+    }
     PoolOptions that = (PoolOptions) o;
-
-    if (maxSize != that.maxSize) return false;
-
-    return true;
+    return maxSize == that.maxSize
+        && maxWaitQueueSize == that.maxWaitQueueSize
+        && connectionReleaseDelay == that.connectionReleaseDelay;
   }
 
   @Override
   public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + maxSize;
-    return result;
+    return Objects.hash(maxSize, maxWaitQueueSize, connectionReleaseDelay);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
@@ -48,7 +48,7 @@ public abstract class PoolBase<P extends Pool> extends SqlClientBase<P> implemen
     super(tracer, metrics);
     this.vertx = context.owner();
     this.factory = factory;
-    this.pool = new ConnectionPool(factory, context, poolOptions.getMaxSize(), poolOptions.getMaxWaitQueueSize());
+    this.pool = new ConnectionPool(factory, context, poolOptions);
     this.closeFuture = new CloseFuture(this);
   }
 

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/PoolOptionsTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/PoolOptionsTest.java
@@ -1,0 +1,35 @@
+package io.vertx.sqlclient;
+
+import static org.junit.Assert.*;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+public class PoolOptionsTest {
+  @Test
+  public void numberOfPoolOptions() {
+    JsonObject json = new JsonObject();
+    PoolOptionsConverter.toJson(new PoolOptions(), json);
+    // if fields change equals() and hasCode() must change
+    assertEquals(json.fieldNames().toString(), 3, json.fieldNames().size());
+  }
+
+  @Test
+  public void test() {
+    PoolOptions poolOptions = new PoolOptions();
+    assertHashAndEquals(true, poolOptions, new PoolOptions());
+    assertHashAndEquals(false, poolOptions, new PoolOptions().setMaxSize(11));
+    assertHashAndEquals(false, poolOptions, new PoolOptions().setMaxWaitQueueSize(11));
+    assertHashAndEquals(false, poolOptions, new PoolOptions().setConnectionReleaseDelay(11));
+  }
+
+  private void assertHashAndEquals(boolean equalExpected, PoolOptions poolOptions1, PoolOptions poolOptions2) {
+    if (equalExpected) {
+      assertTrue(poolOptions1.equals(poolOptions2));
+      assertEquals(poolOptions2.hashCode(), poolOptions1.hashCode());
+    } else {
+      assertFalse(poolOptions1.equals(poolOptions2));
+      assertNotEquals(poolOptions2.hashCode(), poolOptions1.hashCode());
+    }
+  }
+}


### PR DESCRIPTION
Close idle connections that wait in the pool for connectionReleaseDelay
milliseconds. Defaults to 0 = keep them forever.

The option name is taken from vertx-mysql-postgresql-client:
https://github.com/vert-x3/vertx-mysql-postgresql-client/blob/3.9.1/vertx-mysql-postgresql-client-jasync/src/main/java/io/vertx/ext/asyncsql/impl/pool/AsyncC$

Implementation
If connectionReleaseDelay is > 0:
When a connection is put into the pool create a timer
that closes the connection and removes it from the pool: expire().
If a connection in the pool is acquired before the timer
fires the timer is cancelled: cancelIdleTimer().

In PoolOptions
* add connectionReleaseDelay option
* fix and unit test equals() and hashCode()

In ConnectionPool
* add constructor that takes PoolOptions to avoid long parameter lists
* add package-private allSize() for unit testing
* rename and move release(PooledConnection) to PooledConnection.addToPool()
  to avoid a name that is misleading if connectionReleaseDelay exists