### PR TITLE
FOLIO-2840: Unsigned long HexSequence for name of PgPreparedStatement

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Bind.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Bind.java
@@ -22,11 +22,11 @@ package io.vertx.pgclient.impl.codec;
  */
 final class Bind {
 
-  final long statement;
+  final byte[] statement;
   final DataType[] paramTypes;
   final PgColumnDesc[] resultColumns;
 
-  Bind(long statement, DataType[] paramTypes, PgColumnDesc[] resultColumns) {
+  Bind(byte[] statement, DataType[] paramTypes, PgColumnDesc[] resultColumns) {
     this.statement = statement;
     this.paramTypes = paramTypes;
     this.resultColumns = resultColumns;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Describe.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Describe.java
@@ -22,10 +22,10 @@ package io.vertx.pgclient.impl.codec;
  */
 class Describe {
 
-  final long statement;
+  final byte[] statement;
   final String portal;
 
-  Describe(long statement, String portal) {
+  Describe(byte[] statement, String portal) {
     this.statement = statement;
     this.portal = portal;
   }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -24,9 +24,9 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.SocketChannel;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.pgclient.impl.util.Util;
+import io.vertx.sqlclient.impl.HexSequence;
 import io.vertx.sqlclient.impl.ParamDesc;
 import io.vertx.sqlclient.impl.RowDesc;
-import io.vertx.sqlclient.impl.StringLongSequence;
 import io.vertx.sqlclient.impl.command.CloseConnectionCommand;
 import io.vertx.sqlclient.impl.command.CloseCursorCommand;
 import io.vertx.sqlclient.impl.command.CloseStatementCommand;
@@ -37,7 +37,6 @@ import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
 import io.vertx.sqlclient.impl.command.SimpleQueryCommand;
 
 import java.util.ArrayDeque;
-import java.util.List;
 import java.util.Map;
 
 import static io.vertx.pgclient.impl.util.Util.writeCString;
@@ -65,7 +64,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
   private ChannelHandlerContext ctx;
   private ByteBuf out;
   private PgDecoder dec;
-  private final StringLongSequence psSeq = new StringLongSequence(); // used for generating named prepared statement name
+  private final HexSequence psSeq = new HexSequence(); // used for generating named prepared statement name
 
   PgEncoder(PgDecoder dec, ArrayDeque<PgCommandCodec<?, ?>> inflight) {
     this.inflight = inflight;
@@ -193,17 +192,13 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
-  void writeClosePreparedStatement(long statementName) {
+  void writeClosePreparedStatement(byte[] statementName) {
     ensureBuffer();
     int pos = out.writerIndex();
     out.writeByte(CLOSE);
     out.writeInt(0);
     out.writeByte('S'); // 'S' to close a prepared statement or 'P' to close a portal
-    if (statementName == 0) {
-      out.writeByte(0);
-    } else {
-      out.writeLong(statementName);
-    }
+    out.writeBytes(statementName);
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
@@ -306,9 +301,9 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     int pos = out.writerIndex();
     out.writeByte(DESCRIBE);
     out.writeInt(0);
-    if (describe.statement != 0) {
+    if (describe.statement.length > 1) {
       out.writeByte('S');
-      out.writeLong(describe.statement);
+      out.writeBytes(describe.statement);
     } else if (describe.portal != null) {
       out.writeByte('P');
       Util.writeCStringUTF8(out, describe.portal);
@@ -319,16 +314,12 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos- 1);
   }
 
-  void writeParse(String sql, long statement, DataType[] parameterTypes) {
+  void writeParse(String sql, byte[] statement, DataType[] parameterTypes) {
     ensureBuffer();
     int pos = out.writerIndex();
     out.writeByte(PARSE);
     out.writeInt(0);
-    if (statement == 0) {
-      out.writeByte(0);
-    } else {
-      out.writeLong(statement);
-    }
+    out.writeBytes(statement);
     Util.writeCStringUTF8(out, sql);
     if (parameterTypes == null) {
       // Let pg figure out
@@ -390,11 +381,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
       out.writeCharSequence(portal, UTF_8);
     }
     out.writeByte(0);
-    if (bind.statement == 0) {
-      out.writeByte(0);
-    } else {
-      out.writeLong(bind.statement);
-    }
+    out.writeBytes(bind.statement);
     int paramLen = paramValues.size();
     out.writeShort(paramLen);
     // Parameter formats
@@ -442,7 +429,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     }
   }
 
-  long nextStatementName() {
+  byte[] nextStatementName() {
     return psSeq.next();
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
@@ -29,7 +29,7 @@ class PgPreparedStatement implements PreparedStatement {
   final PgRowDesc rowDesc;
   final boolean cached;
 
-  PgPreparedStatement(String sql, long statement, PgParamDesc paramDesc, PgRowDesc rowDesc, boolean cached) {
+  PgPreparedStatement(String sql, byte[] statement, PgParamDesc paramDesc, PgRowDesc rowDesc, boolean cached) {
     this.paramDesc = paramDesc;
     this.rowDesc = rowDesc;
     this.sql = sql;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
@@ -26,7 +26,7 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
   private PgParamDesc parameterDesc;
   private PgRowDesc rowDesc;
 
-  private long statement;
+  private byte[] statement;
 
   PrepareStatementCommandCodec(PrepareStatementCommand cmd) {
     super(cmd);
@@ -38,7 +38,7 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
       statement = encoder.nextStatementName();
     } else {
       // Use unnamed prepared statements that don't need to be closed
-      statement = 0L;
+      statement = new byte[] { 0 };
     }
 
     List<Class<?>> parameterTypes = cmd.parameterTypes();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/HexSequence.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/HexSequence.java
@@ -11,7 +11,7 @@
 
 package io.vertx.sqlclient.impl;
 
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 /**
@@ -19,6 +19,8 @@ import java.util.Locale;
  *
  * The hex number is left padded to start with at least three 0
  * and to have at least seven digits.
+ *
+ * After 000FFFFFFFFFFFFFFFF it will restart with 0000000.
  *
  * The generated sequence:
  * <pre>
@@ -35,75 +37,37 @@ import java.util.Locale;
  * 000FFFFFF
  * 0001000000
  * ...
+ * 000FFFFFFFFFFFFFFFF
  * </pre>
  */
 public class HexSequence {
-  private byte[] hex;
+  private long i;
 
   /**
    * Start the sequence with 0000000.
    */
   public HexSequence() {
-    // seven 0 digits and a zero byte
-    hex = new byte[] { '0', '0', '0', '0', '0', '0', '0', 0 };
+    i = 0;
   }
 
   /**
-   * @param startValue first value returned by {@link #next()}.
+   * @param startValue unsigned long for the first value returned by {@link #next()}
    */
-  public HexSequence(int startValue) {
-    if (startValue < 0) {
-      throw new IllegalArgumentException("startValue must not be negative: " + startValue);
-    }
-    hex = String.format(Locale.ROOT, "000%04X\0", startValue).getBytes();
+  public HexSequence(long startValue) {
+    i = startValue;
   }
 
   /**
-   * @return a copy of the current hex value, terminated by a zero byte.
+   * @return a copy of the next hex value, terminated by a zero byte.
    */
   public byte[] next() {
-    byte[] ret = Arrays.copyOf(hex, hex.length);
-    increment();
-    return ret;
-  }
-
-  private void increment() {
-    for (int i = hex.length - 2; i >= 3; i--) {
-      byte number = next(hex[i]);
-      hex[i] = number;
-      if (number != '0') {
-        return;
-      }
-    }
-    hex = new byte [hex.length + 1];
-    hex[0] = '0';
-    hex[1] = '0';
-    hex[2] = '0';
-    hex[3] = '1';
-    for (int i = 4; i < hex.length - 1; i++) {
-      hex[i] = '0';
-    }
-    hex[hex.length - 1] = 0;
-  }
-
-  private byte next(byte c) {
-    switch (c) {
-    case '0': return '1';
-    case '1': return '2';
-    case '2': return '3';
-    case '3': return '4';
-    case '4': return '5';
-    case '5': return '6';
-    case '6': return '7';
-    case '7': return '8';
-    case '8': return '9';
-    case '9': return 'A';
-    case 'A': return 'B';
-    case 'B': return 'C';
-    case 'C': return 'D';
-    case 'D': return 'E';
-    case 'E': return 'F';
-    default: return '0';
+    String hex = Long.toUnsignedString(i, 16).toUpperCase(Locale.ROOT);
+    i++;
+    switch (hex.length()) {
+    case 1: return ("000000" + hex + "\0").getBytes(StandardCharsets.US_ASCII);
+    case 2: return ("00000" + hex + "\0").getBytes(StandardCharsets.US_ASCII);
+    case 3: return ("0000" + hex + "\0").getBytes(StandardCharsets.US_ASCII);
+    default: return ("000" + hex + "\0").getBytes(StandardCharsets.US_ASCII);
     }
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/HexSequence.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/HexSequence.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.sqlclient.impl;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * A sequence of hex values, each terminated by a zero byte.
+ *
+ * The hex number is left padded to start with at least three 0
+ * and to have at least seven digits.
+ *
+ * The generated sequence:
+ * <pre>
+ * 0000000
+ * 0000001
+ * 0000002
+ * ...
+ * 000FFFF
+ * 00010000
+ * ...
+ * 000FFFFF
+ * 000100000
+ * ...
+ * 000FFFFFF
+ * 0001000000
+ * ...
+ * </pre>
+ */
+public class HexSequence {
+  private byte[] hex;
+
+  /**
+   * Start the sequence with 0000000.
+   */
+  public HexSequence() {
+    // seven 0 digits and a zero byte
+    hex = new byte[] { '0', '0', '0', '0', '0', '0', '0', 0 };
+  }
+
+  /**
+   * @param startValue first value returned by {@link #next()}.
+   */
+  public HexSequence(int startValue) {
+    if (startValue < 0) {
+      throw new IllegalArgumentException("startValue must not be negative: " + startValue);
+    }
+    hex = String.format(Locale.ROOT, "000%04X\0", startValue).getBytes();
+  }
+
+  /**
+   * @return a copy of the current hex value, terminated by a zero byte.
+   */
+  public byte[] next() {
+    byte[] ret = Arrays.copyOf(hex, hex.length);
+    increment();
+    return ret;
+  }
+
+  private void increment() {
+    for (int i = hex.length - 2; i >= 3; i--) {
+      byte number = next(hex[i]);
+      hex[i] = number;
+      if (number != '0') {
+        return;
+      }
+    }
+    hex = new byte [hex.length + 1];
+    hex[0] = '0';
+    hex[1] = '0';
+    hex[2] = '0';
+    hex[3] = '1';
+    for (int i = 4; i < hex.length - 1; i++) {
+      hex[i] = '0';
+    }
+    hex[hex.length - 1] = 0;
+  }
+
+  private byte next(byte c) {
+    switch (c) {
+    case '0': return '1';
+    case '1': return '2';
+    case '2': return '3';
+    case '3': return '4';
+    case '4': return '5';
+    case '5': return '6';
+    case '6': return '7';
+    case '7': return '8';
+    case '8': return '9';
+    case '9': return 'A';
+    case 'A': return 'B';
+    case 'B': return 'C';
+    case 'C': return 'D';
+    case 'D': return 'E';
+    case 'E': return 'F';
+    default: return '0';
+    }
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StringLongSequence.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StringLongSequence.java
@@ -21,6 +21,9 @@ public class StringLongSequence {
 
   private short count;
 
+  /**
+   * @return the hex numbers 0000000 to 000FFFF, then starts from 0000000 again
+   */
   public long next() {
     short val = count++;
     long next = 0x30_30_30_00_00_00_00_00L;

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/HexSequenceTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/HexSequenceTest.java
@@ -16,11 +16,6 @@ import org.junit.Test;
 
 public class HexSequenceTest {
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNegativeStartValue() {
-    new HexSequence(-1);
-  }
-
   @Test
   public void testStartValue() {
     assertEquals("0000000",   new HexSequence().next());
@@ -63,9 +58,12 @@ public class HexSequenceTest {
     assertIncrement("00010000",   0x000FFFF);
     assertIncrement("000100000",  0x000FFFFF);
     assertIncrement("0001000000", 0x000FFFFFF);
+    assertIncrement("000FFFFFFFFFFFFFFFF", 0x000FFFFFFFFFFFFFFFEL);
+    assertIncrement("0000000",             0x000FFFFFFFFFFFFFFFFL);
+    assertIncrement("0000000",             -1);
   }
 
-  private static void assertIncrement(String incremented, int start) {
+  private static void assertIncrement(String incremented, long start) {
     HexSequence hex = new HexSequence(start);
     hex.next();
     assertEquals(incremented, hex.next());

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/HexSequenceTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/HexSequenceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.sqlclient.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HexSequenceTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeStartValue() {
+    new HexSequence(-1);
+  }
+
+  @Test
+  public void testStartValue() {
+    assertEquals("0000000",   new HexSequence().next());
+    assertEquals("0000000",   new HexSequence(0).next());
+    assertEquals("000000A",   new HexSequence(0xA).next());
+    assertEquals("000FFFF",   new HexSequence(0xFFFF).next());
+    assertEquals("00010000",  new HexSequence(0x10000).next());
+    assertEquals("000ABCDEF", new HexSequence(0xABCDEF).next());
+  }
+
+  @Test
+  public void testSequence() {
+    HexSequence seq = new HexSequence();
+    assertEquals("0000000", seq.next());
+    assertEquals("0000001", seq.next());
+    assertEquals("0000002", seq.next());
+    assertEquals("0000003", seq.next());
+    assertEquals("0000004", seq.next());
+    assertEquals("0000005", seq.next());
+    assertEquals("0000006", seq.next());
+    assertEquals("0000007", seq.next());
+    assertEquals("0000008", seq.next());
+    assertEquals("0000009", seq.next());
+    assertEquals("000000A", seq.next());
+    assertEquals("000000B", seq.next());
+    assertEquals("000000C", seq.next());
+    assertEquals("000000D", seq.next());
+    assertEquals("000000E", seq.next());
+    assertEquals("000000F", seq.next());
+    assertEquals("0000010", seq.next());
+    assertEquals("0000011", seq.next());
+  }
+
+  @Test
+  public void testIncrement() {
+    assertIncrement("0000100",    0x00000FF);
+    assertIncrement("0000F00",    0x0000EFF);
+    assertIncrement("0001000",    0x0000FFF);
+    assertIncrement("000A000",    0x0009FFF);
+    assertIncrement("00010000",   0x000FFFF);
+    assertIncrement("000100000",  0x000FFFFF);
+    assertIncrement("0001000000", 0x000FFFFFF);
+  }
+
+  private static void assertIncrement(String incremented, int start) {
+    HexSequence hex = new HexSequence(start);
+    hex.next();
+    assertEquals(incremented, hex.next());
+  }
+
+  private static void assertEquals(String expected, byte[] actual) {
+    Assert.assertEquals(expected + "\0", new String(actual));
+  }
+}


### PR DESCRIPTION
This is the same as the upstream pull request https://github.com/eclipse-vertx/vertx-sql-client/pull/737

Replace StringLongSequence by HexSequence
based on an unsigned long counter
to avoid duplicate prepared statement name in
PgPreparedStatement.

StringLongSequence wraps around to 0000000 after 000FFFF.
HexSequence wraps around to 0000000 after 000FFFFFFFFFFFFFFFF.

Example:

```
conn.prepare("SELECT 1", ctx.asyncAssertSuccess(ps1 -> {
  for (int i=1; i<=0x10000; i++) {
    conn.prepare("SELECT 2", ctx.asyncAssertSuccess(ps2 -> {
      ps2.query().execute(ctx.asyncAssertSuccess(done -> ps2.close()));
    }));
  }
}));
```

This example has a first prepared statement that is not closed.
0x10000 other prepared statements are created and closed, they
use the names 0000001 to 000FFFF and finally 0000000. The
0000000 is still in use by the first prepared statement and
causes this exception:

"message": "prepared statement "0000000" already exists",
"severity": "ERROR", "code": "42P05", "file": "prepare.c",
"line": "475", "routine": "StorePreparedStatement"

The new HexSequence uses the full number range of an
unsigned long making it unlikely that a name still is in use.

Fixes #732.